### PR TITLE
Fix name of RAHP B

### DIFF
--- a/Public/routes-data/fall22-event.gpx
+++ b/Public/routes-data/fall22-event.gpx
@@ -48,7 +48,7 @@
 		<name>Bryckwyck</name>
 	</wpt>
 	<wpt lat="42.735535" lon="-73.664404">
-		<name>RHAP B</name>
+		<name>RAHP B</name>
 	</wpt>
 	<wpt lat="42.737002" lon="-73.666682">
 		<name>Georgian Court</name>

--- a/Public/routes-data/fall22.gpx
+++ b/Public/routes-data/fall22.gpx
@@ -51,7 +51,7 @@
 		<name>Bryckwyck</name>
 	</wpt>
 	<wpt lat="42.735535" lon="-73.664404">
-		<name>RHAP B</name>
+		<name>RAHP B</name>
 	</wpt>
 	<wpt lat="42.737002" lon="-73.666682">
 		<name>Georgian Court</name>


### PR DESCRIPTION
The full name of the apartments is Rensselaer Apartment Housing Project and should therefore be RAHP and not RHAP.